### PR TITLE
Change NarfduinoBattery to use properly named constructors

### DIFF
--- a/Narfduino_Libraries/NarfduinoBattery.cpp
+++ b/Narfduino_Libraries/NarfduinoBattery.cpp
@@ -21,14 +21,14 @@
 #include "NarfduinoBattery.h"
 
 
-NarfduinoBattery::Narfduino( byte _BatteryPin )
+NarfduinoBattery::NarfduinoBattery( byte _BatteryPin )
 {
   BatteryPin = _BatteryPin;
 }
 
-NarfduinoBattery::Narfduino()
+NarfduinoBattery::NarfduinoBattery()
 {
-  Narfduino( _NARFDUINO_PIN_BATTERY );
+  NarfduinoBattery( _NARFDUINO_PIN_BATTERY );
 }
 
 // Call this once, to initialise the library.

--- a/Narfduino_Libraries/NarfduinoBattery.h
+++ b/Narfduino_Libraries/NarfduinoBattery.h
@@ -69,8 +69,8 @@ class NarfduinoBattery
 {
   public:
     // Constructors   
-    Narfduino( byte _BatteryPin ); // Use if you want to override the default pin.
-    Narfduino();
+    NarfduinoBattery( byte _BatteryPin ); // Use if you want to override the default pin.
+    NarfduinoBattery();
 
 
     // ***************************************


### PR DESCRIPTION
Changed constructor calls to use NarfduinoBattery instead of just Narfduino, which was causing warnings in my code.